### PR TITLE
Fix for support ver 0.5.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,4 +42,4 @@ If you want to build only virtualbox or vmware
 
 Supported versions
 ------------------
-This templates was tested using a packer 0.4.0 .
+This templates was tested using a packer 0.5.1 .

--- a/centos-6.4/template.json
+++ b/centos-6.4/template.json
@@ -48,7 +48,7 @@
       "http_directory": "http",
       "iso_checksum": "4a5fa01c81cc300f4729136e28ebe600",
       "iso_checksum_type": "md5",
-      "iso_url": "http://ftp.iij.ad.jp/pub/linux/centos/6.4/isos/x86_64/CentOS-6.4-x86_64-minimal.iso",
+      "iso_url": "http://ftp.riken.jp/Linux/centos/6.4/isos/x86_64/CentOS-6.4-x86_64-minimal.iso",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_port": 22,

--- a/centos-6.4/template.json
+++ b/centos-6.4/template.json
@@ -4,7 +4,7 @@
       "type": "shell",
       "execute_command": "echo 'vagrant'|sudo -S sh '{{.Path}}'",
       "override": {
-        "virtualbox": {
+        "virtualbox-iso": {
           "scripts": [
             "scripts/base.sh",
             "scripts/vagrant.sh",
@@ -12,7 +12,7 @@
             "scripts/cleanup.sh"
           ]
         },
-        "vmware": {
+        "vmware-iso": {
           "scripts": [
             "scripts/base.sh",
             "scripts/vagrant.sh",
@@ -26,17 +26,19 @@
   "post-processors": [
     {
       "type": "vagrant",
-      "virtualbox": {
-        "output": "centos-6-4-x64-virtualbox.box"
-      },
-      "vmware": {
-        "output": "centos-6-4-x64-vmware.box"
+      "override": {
+        "virtualbox": {
+          "output": "centos-6-4-x64-virtualbox.box"
+        },
+        "vmware": {
+          "output": "centos-6-4-x64-vmware.box"
+        }
       }
     }
   ],
   "builders": [
     {
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "boot_command": [
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg<enter><wait>"
       ],
@@ -60,7 +62,7 @@
       ]
     },
     {
-      "type": "vmware",
+      "type": "vmware-iso",
       "boot_command": [
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg<enter><wait>"
       ],

--- a/centos-6.5/template.json
+++ b/centos-6.5/template.json
@@ -4,7 +4,7 @@
       "type": "shell",
       "execute_command": "echo 'vagrant'|sudo -S sh '{{.Path}}'",
       "override": {
-        "virtualbox": {
+        "virtualbox-iso": {
           "scripts": [
             "scripts/base.sh",
             "scripts/vagrant.sh",
@@ -12,7 +12,7 @@
             "scripts/cleanup.sh"
           ]
         },
-        "vmware": {
+        "vmware-iso": {
           "scripts": [
             "scripts/base.sh",
             "scripts/vagrant.sh",
@@ -26,17 +26,19 @@
   "post-processors": [
     {
       "type": "vagrant",
-      "virtualbox": {
-        "output": "centos-6-5-x64-virtualbox.box"
-      },
-      "vmware": {
-        "output": "centos-6-5-x64-vmware.box"
+      "override": {
+        "virtualbox": {
+          "output": "centos-6-5-x64-virtualbox.box"
+        },
+        "vmware": {
+          "output": "centos-6-5-x64-vmware.box"
+        }
       }
     }
   ],
   "builders": [
     {
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "boot_command": [
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg<enter><wait>"
       ],
@@ -60,7 +62,7 @@
       ]
     },
     {
-      "type": "vmware",
+      "type": "vmware-iso",
       "boot_command": [
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg<enter><wait>"
       ],

--- a/ubuntu-12.04/template.json
+++ b/ubuntu-12.04/template.json
@@ -4,7 +4,7 @@
       "type": "shell",
       "execute_command": "echo 'vagrant'|sudo -S sh '{{.Path}}'",
       "override": {
-        "virtualbox": {
+        "virtualbox-iso": {
           "scripts": [
             "scripts/base.sh",
             "scripts/vagrant.sh",
@@ -13,7 +13,7 @@
             "scripts/zerodisk.sh"
           ]
         },
-        "vmware": {
+        "vmware-iso": {
           "scripts": [
             "scripts/base.sh",
             "scripts/vagrant.sh",
@@ -27,17 +27,19 @@
   "post-processors": [
     {
       "type": "vagrant",
-      "virtualbox": {
-        "output": "ubuntu-12-04-x64-virtualbox.box"
-      },
-      "vmware": {
-        "output": "ubuntu-12-04-x64-vmware.box"
+      "override": {
+        "virtualbox": {
+          "output": "ubuntu-12-04-x64-virtualbox.box"
+        },
+        "vmware": {
+          "output": "ubuntu-12-04-x64-vmware.box"
+        }
       }
     }
   ],
   "builders": [
     {
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "boot_command": [
         "<esc><wait>",
         "<esc><wait>",
@@ -80,7 +82,7 @@
       ]
     },
     {
-      "type": "vmware",
+      "type": "vmware-iso",
       "boot_command": [
         "<esc><wait>",
         "<esc><wait>",

--- a/ubuntu-13.04/template.json
+++ b/ubuntu-13.04/template.json
@@ -4,7 +4,7 @@
       "type": "shell",
       "execute_command": "echo 'vagrant'|sudo -S sh '{{.Path}}'",
       "override": {
-        "virtualbox": {
+        "virtualbox-iso": {
           "scripts": [
             "scripts/base.sh",
             "scripts/vagrant.sh",
@@ -13,7 +13,7 @@
             "scripts/zerodisk.sh"
           ]
         },
-        "vmware": {
+        "vmware-iso": {
           "scripts": [
             "scripts/base.sh",
             "scripts/vagrant.sh",
@@ -28,17 +28,19 @@
   "post-processors": [
     {
       "type": "vagrant",
-      "virtualbox": {
-        "output": "ubuntu-13-04-x64-virtualbox.box"
-      },
-      "vmware": {
-        "output": "ubuntu-13-04-x64-vmware.box"
+      "override": {
+        "virtualbox": {
+          "output": "ubuntu-13-04-x64-virtualbox.box"
+        },
+        "vmware": {
+          "output": "ubuntu-13-04-x64-vmware.box"
+        }
       }
     }
   ],
   "builders": [
     {
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "boot_command": [
         "<esc><wait>",
         "<esc><wait>",
@@ -81,7 +83,7 @@
       ]
     },
     {
-      "type": "vmware",
+      "type": "vmware-iso",
       "boot_command": [
         "<esc><wait>",
         "<esc><wait>",

--- a/ubuntu-13.10/template.json
+++ b/ubuntu-13.10/template.json
@@ -4,7 +4,7 @@
       "type": "shell",
       "execute_command": "echo 'vagrant'|sudo -S sh '{{.Path}}'",
       "override": {
-        "virtualbox": {
+        "virtualbox-iso": {
           "scripts": [
             "scripts/base.sh",
             "scripts/vagrant.sh",
@@ -13,7 +13,7 @@
             "scripts/zerodisk.sh"
           ]
         },
-        "vmware": {
+        "vmware-iso": {
           "scripts": [
             "scripts/base.sh",
             "scripts/vagrant.sh",
@@ -28,17 +28,19 @@
   "post-processors": [
     {
       "type": "vagrant",
-      "virtualbox": {
-        "output": "ubuntu-13-10-x64-virtualbox.box"
-      },
-      "vmware": {
-        "output": "ubuntu-13-10-x64-vmware.box"
+      "override": {
+        "virtualbox": {
+          "output": "ubuntu-13-10-x64-virtualbox.box"
+        },
+        "vmware": {
+          "output": "ubuntu-13-10-x64-vmware.box"
+        }
       }
     }
   ],
   "builders": [
     {
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "boot_command": [
         "<esc><wait>",
         "<esc><wait>",
@@ -81,7 +83,7 @@
       ]
     },
     {
-      "type": "vmware",
+      "type": "vmware-iso",
       "boot_command": [
         "<esc><wait>",
         "<esc><wait>",


### PR DESCRIPTION
Packer が 0.5.0 で後方互換を切る仕様変更があったため、対応しました。

手元の Virtualbox では全て動作を確認できていますが、VMWare のバージョンが異なり確認できていません。
