### PR TITLE
Fix kernel-devel package path

### DIFF
--- a/centos-6.4/scripts/base.sh
+++ b/centos-6.4/scripts/base.sh
@@ -1,3 +1,5 @@
 sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
-yum -y install gcc make gcc-c++ kernel-devel-`uname -r` perl
+yum -y install gcc make gcc-c++ \
+		http://vault.centos.org/6.4/os/x86_64/Packages/kernel-devel-`uname -r`.rpm \
+		perl nfs-utils
 

--- a/centos-6.4/scripts/base.sh
+++ b/centos-6.4/scripts/base.sh
@@ -1,5 +1,5 @@
 sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
 yum -y install gcc make gcc-c++ \
 		http://vault.centos.org/6.4/os/x86_64/Packages/kernel-devel-`uname -r`.rpm \
-		perl nfs-utils
+		perl
 


### PR DESCRIPTION
kernel-devel-2.6.32-358.el6.x86_64がyumリポジトリ上からなくなっていたので、
vault.centos.orgのURLを参照するようにしました。
VMWareでは確認していません。
