### PR TITLE
Use centos-vault for CentOS 6.4 ISO image and packages

### DIFF
--- a/centos-6.4/http/ks.cfg
+++ b/centos-6.4/http/ks.cfg
@@ -32,6 +32,9 @@ kernel-headers
 %end
 
 %post
+/bin/sed -i -e 's/^mirrorlist=/#&/;s|^#baseurl=http://mirror.centos.org/centos/$releasever/|baseurl=http://vault.centos.org/6.4/|' /etc/yum.repos.d/CentOS-Base.repo
+/bin/sed -i -e 's/^enabled=1/enabled=0/' /etc/yum/pluginconf.d/fastestmirror.conf
+
 /usr/bin/yum -y install sudo
 /usr/sbin/groupadd -g 501 vagrant
 /usr/sbin/useradd vagrant -u 501 -g vagrant -G wheel

--- a/centos-6.4/template.json
+++ b/centos-6.4/template.json
@@ -48,7 +48,7 @@
       "http_directory": "http",
       "iso_checksum": "4a5fa01c81cc300f4729136e28ebe600",
       "iso_checksum_type": "md5",
-      "iso_url": "http://ftp.riken.jp/Linux/centos/6.4/isos/x86_64/CentOS-6.4-x86_64-minimal.iso",
+      "iso_url": "http://archive.kernel.org/centos-vault/6.4/isos/x86_64/CentOS-6.4-x86_64-minimal.iso",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_port": 22,


### PR DESCRIPTION
This is a pull request for using centos-vault for CentOS 6.4 ISO image and packages.

I got an error for the old iso_url.
Without the change in http/ks.cfg, when I installed perl for example, el6_6 package was installed.

Could you review this?
Thanks!
