### PR TITLE
Add template for CentOS 7.1

### DIFF
--- a/centos-7.1/http/ks.cfg
+++ b/centos-7.1/http/ks.cfg
@@ -1,0 +1,41 @@
+install
+cdrom
+lang en_US.UTF-8
+keyboard us
+network --onboot yes --device eth0 --bootproto dhcp --noipv6
+rootpw --plaintext vagrant
+firewall --enabled --service=ssh
+authconfig --enableshadow --passalgo=sha512
+selinux --disabled
+timezone Asia/Tokyo
+bootloader --location=mbr --driveorder=sda --append="crashkernel=auto rhgb quiet"
+
+text
+skipx
+zerombr
+
+clearpart --all --initlabel
+autopart
+
+auth  --useshadow  --enablemd5
+firstboot --disabled
+reboot
+
+%packages --ignoremissing
+@core
+bzip2
+kernel-devel
+kernel-headers
+-ipw2100-firmware
+-ipw2200-firmware
+-ivtv-firmware
+%end
+
+%post
+/usr/bin/yum -y install sudo
+/usr/sbin/groupadd -g 501 vagrant
+/usr/sbin/useradd vagrant -u 501 -g vagrant -G wheel
+echo "vagrant"|passwd --stdin vagrant
+echo "vagrant        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
+chmod 0440 /etc/sudoers.d/vagrant
+%end

--- a/centos-7.1/scripts/base.sh
+++ b/centos-7.1/scripts/base.sh
@@ -1,0 +1,3 @@
+sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
+yum -y install gcc make gcc-c++ kernel-devel-`uname -r` perl
+

--- a/centos-7.1/scripts/cleanup.sh
+++ b/centos-7.1/scripts/cleanup.sh
@@ -1,0 +1,5 @@
+yum -y erase gtk2 libX11 hicolor-icon-theme avahi freetype bitstream-vera-fonts
+yum -y clean all
+rm -rf VBoxGuestAdditions_*.iso
+rm -rf /tmp/rubygems-*
+

--- a/centos-7.1/scripts/vagrant.sh
+++ b/centos-7.1/scripts/vagrant.sh
@@ -1,0 +1,6 @@
+date > /etc/vagrant_box_build_time
+
+mkdir -pm 700 /home/vagrant/.ssh
+curl -L https://raw.githubusercontent.com/mitchellh/vagrant/master/keys/vagrant.pub -o /home/vagrant/.ssh/authorized_keys
+chmod 0600 /home/vagrant/.ssh/authorized_keys
+chown -R vagrant:vagrant /home/vagrant/.ssh

--- a/centos-7.1/scripts/virtualbox.sh
+++ b/centos-7.1/scripts/virtualbox.sh
@@ -1,0 +1,7 @@
+VBOX_VERSION=$(cat /home/vagrant/.vbox_version)
+cd /tmp
+mount -o loop /home/vagrant/VBoxGuestAdditions_$VBOX_VERSION.iso /mnt
+sh /mnt/VBoxLinuxAdditions.run
+umount /mnt
+rm -rf /home/vagrant/VBoxGuestAdditions_*.iso
+

--- a/centos-7.1/scripts/vmware.sh
+++ b/centos-7.1/scripts/vmware.sh
@@ -1,0 +1,15 @@
+yum install -y fuse-libs
+mkdir -p /mnt/vmware
+mount -o loop /home/vagrant/linux.iso /mnt/vmware
+
+cd /tmp
+tar xzf /mnt/vmware/VMwareTools-*.tar.gz
+
+umount /mnt/vmware
+rm -fr /home/vagrant/linux.iso
+
+/tmp/vmware-tools-distrib/vmware-install.pl -d
+rm -fr /tmp/vmware-tools-distrib
+
+rm -rf /etc/udev/rules.d/70-persistent-net.rules
+sed -i "s/HWADDR=.*//" /etc/sysconfig/network-scripts/ifcfg-eth0

--- a/centos-7.1/scripts/zerodisk.sh
+++ b/centos-7.1/scripts/zerodisk.sh
@@ -1,0 +1,3 @@
+dd if=/dev/zero of=/EMPTY bs=1M
+rm -f /EMPTY
+

--- a/centos-7.1/template.json
+++ b/centos-7.1/template.json
@@ -1,0 +1,89 @@
+{
+  "provisioners": [
+    {
+      "type": "shell",
+      "execute_command": "echo 'vagrant'|sudo -S sh '{{.Path}}'",
+      "override": {
+        "virtualbox-iso": {
+          "scripts": [
+            "scripts/base.sh",
+            "scripts/vagrant.sh",
+            "scripts/virtualbox.sh",
+            "scripts/cleanup.sh"
+          ]
+        },
+        "vmware-iso": {
+          "scripts": [
+            "scripts/base.sh",
+            "scripts/vagrant.sh",
+            "scripts/vmware.sh",
+            "scripts/cleanup.sh"
+          ]
+        }
+      }
+    }
+  ],
+  "post-processors": [
+    {
+      "type": "vagrant",
+      "override": {
+        "virtualbox": {
+          "output": "centos-7-1-x64-virtualbox.box"
+        },
+        "vmware": {
+          "output": "centos-7-1-x64-vmware.box"
+        }
+      }
+    }
+  ],
+  "builders": [
+    {
+      "type": "virtualbox-iso",
+      "boot_command": [
+        "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg<enter><wait>"
+      ],
+      "boot_wait": "10s",
+      "disk_size": 40520,
+      "guest_os_type": "RedHat_64",
+      "http_directory": "http",
+      "iso_checksum": "1795184136b8bdddabe50453cc2cc2d46f0f7c5e",
+      "iso_checksum_type": "sha1",
+      "iso_url": "http://ftp.iij.ad.jp/pub/linux/centos/7.1.1503/isos/x86_64/CentOS-7-x86_64-DVD-1503-01.iso",
+      "ssh_username": "vagrant",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "10000s",
+      "shutdown_command": "echo '/sbin/halt -h -p' > /tmp/shutdown.sh; echo 'vagrant'|sudo -S sh '/tmp/shutdown.sh'",
+      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "virtualbox_version_file": ".vbox_version",
+      "vboxmanage": [
+        [ "modifyvm", "{{.Name}}", "--memory", "512" ],
+        [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
+      ]
+    },
+    {
+      "type": "vmware-iso",
+      "boot_command": [
+        "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg<enter><wait>"
+      ],
+      "boot_wait": "10s",
+      "disk_size": 40520,
+      "guest_os_type": "centos-64",
+      "http_directory": "http",
+      "iso_checksum": "1795184136b8bdddabe50453cc2cc2d46f0f7c5e",
+      "iso_checksum_type": "sha1",
+      "iso_url": "http://ftp.iij.ad.jp/pub/linux/centos/7.1.1503/isos/x86_64/CentOS-7-x86_64-DVD-1503-01.iso",
+      "ssh_username": "vagrant",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "10000s",
+      "shutdown_command": "echo '/sbin/halt -h -p' > /tmp/shutdown.sh; echo 'vagrant'|sudo -S sh '/tmp/shutdown.sh'",
+      "tools_upload_flavor": "linux",
+      "vmx_data": {
+        "memsize": "512",
+        "numvcpus": "1",
+        "cpuid.coresPerSocket": "1"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This is a pull request for adding a template for [CentOS7.1](http://wiki.centos.org/Manuals/ReleaseNotes/CentOS7).

I tested it only for virtualbox-iso provider and released a vagrant box at [hnakamur/centos7.1-x64 | Atlas by HashiCorp](https://atlas.hashicorp.com/hnakamur/boxes/centos7.1-x64).

Could you review this?
Thanks.
