### PR TITLE
udev rules no longer exist in CentOS 7.1

### DIFF
--- a/centos-7.1/scripts/virtualbox.sh
+++ b/centos-7.1/scripts/virtualbox.sh
@@ -1,4 +1,8 @@
 VBOX_VERSION=$(cat /home/vagrant/.vbox_version)
+
+# required for VirtualBox 4.3.26
+yum install -y bzip2
+
 cd /tmp
 mount -o loop /home/vagrant/VBoxGuestAdditions_$VBOX_VERSION.iso /mnt
 sh /mnt/VBoxLinuxAdditions.run

--- a/centos-7.1/scripts/vmware.sh
+++ b/centos-7.1/scripts/vmware.sh
@@ -1,15 +1,1 @@
-yum install -y fuse-libs
-mkdir -p /mnt/vmware
-mount -o loop /home/vagrant/linux.iso /mnt/vmware
-
-cd /tmp
-tar xzf /mnt/vmware/VMwareTools-*.tar.gz
-
-umount /mnt/vmware
-rm -fr /home/vagrant/linux.iso
-
-/tmp/vmware-tools-distrib/vmware-install.pl -d
-rm -fr /tmp/vmware-tools-distrib
-
-rm -rf /etc/udev/rules.d/70-persistent-net.rules
-sed -i "s/HWADDR=.*//" /etc/sysconfig/network-scripts/ifcfg-eth0
+yum install -y fuse-libs open-vm-tools


### PR DESCRIPTION
this simplifies the vmware script for CentOS 7.1
- vmware recommends installing openvm-tools for CentOS 7.1
- udev rules no longer exist in CentOS 7.1
- network configuration scripts have changed, no longer include MAC address
