### PR TITLE
Fix debconf noninteractive setting

### DIFF
--- a/ubuntu-12.04-docker/http/preseed.cfg
+++ b/ubuntu-12.04-docker/http/preseed.cfg
@@ -1,3 +1,4 @@
+debconf debconf/frontend select Noninteractive
 choose-mirror-bin mirror/http/proxy string
 d-i base-installer/kernel/override-image string linux-server
 d-i clock-setup/utc boolean true

--- a/ubuntu-12.04-docker/template.json
+++ b/ubuntu-12.04-docker/template.json
@@ -93,7 +93,6 @@
         " console-setup/ask_detect=false<wait>",
         " console-setup/layoutcode=us<wait>",
         " console-setup/modelcode=pc105<wait>",
-        " debconf/frontend=noninteractive<wait>",
         " debian-installer=en_US<wait>",
         " fb=false<wait>",
         " initrd=/install/initrd.gz<wait>",

--- a/ubuntu-12.04-docker/template.json
+++ b/ubuntu-12.04-docker/template.json
@@ -51,7 +51,6 @@
         " console-setup/ask_detect=false<wait>",
         " console-setup/layoutcode=us<wait>",
         " console-setup/modelcode=pc105<wait>",
-        " debconf/frontend=noninteractive<wait>",
         " debian-installer=en_US<wait>",
         " fb=false<wait>",
         " initrd=/install/initrd.gz<wait>",

--- a/ubuntu-12.04/http/preseed.cfg
+++ b/ubuntu-12.04/http/preseed.cfg
@@ -1,3 +1,4 @@
+debconf debconf/frontend select Noninteractive
 choose-mirror-bin mirror/http/proxy string
 d-i base-installer/kernel/override-image string linux-server
 d-i clock-setup/utc boolean true

--- a/ubuntu-12.04/template.json
+++ b/ubuntu-12.04/template.json
@@ -91,7 +91,6 @@
         " console-setup/ask_detect=false<wait>",
         " console-setup/layoutcode=us<wait>",
         " console-setup/modelcode=pc105<wait>",
-        " debconf/frontend=noninteractive<wait>",
         " debian-installer=en_US<wait>",
         " fb=false<wait>",
         " initrd=/install/initrd.gz<wait>",

--- a/ubuntu-12.04/template.json
+++ b/ubuntu-12.04/template.json
@@ -49,7 +49,6 @@
         " console-setup/ask_detect=false<wait>",
         " console-setup/layoutcode=us<wait>",
         " console-setup/modelcode=pc105<wait>",
-        " debconf/frontend=noninteractive<wait>",
         " debian-installer=en_US<wait>",
         " fb=false<wait>",
         " initrd=/install/initrd.gz<wait>",

--- a/ubuntu-14.04/http/preseed.cfg
+++ b/ubuntu-14.04/http/preseed.cfg
@@ -1,3 +1,4 @@
+debconf debconf/frontend select Noninteractive
 choose-mirror-bin mirror/http/proxy string
 d-i base-installer/kernel/override-image string linux-server
 d-i clock-setup/utc boolean true

--- a/ubuntu-14.04/template.json
+++ b/ubuntu-14.04/template.json
@@ -92,7 +92,6 @@
         " console-setup/ask_detect=false<wait>",
         " console-setup/layoutcode=us<wait>",
         " console-setup/modelcode=pc105<wait>",
-        " debconf/frontend=noninteractive<wait>",
         " debian-installer=en_US<wait>",
         " fb=false<wait>",
         " initrd=/install/initrd.gz<wait>",

--- a/ubuntu-14.04/template.json
+++ b/ubuntu-14.04/template.json
@@ -50,7 +50,6 @@
         " console-setup/ask_detect=false<wait>",
         " console-setup/layoutcode=us<wait>",
         " console-setup/modelcode=pc105<wait>",
-        " debconf/frontend=noninteractive<wait>",
         " debian-installer=en_US<wait>",
         " fb=false<wait>",
         " initrd=/install/initrd.gz<wait>",


### PR DESCRIPTION
When given on the kernel boot command line the setting has no effect,
debconf-get-selections still reports the standard setting "Dialog" after
initial login. This causes e.g. mysql-server to hang during installation,
because it interactively asks for a mysql root password (although mysql-server
is not part of the default installation, I adapted base.sh locally).

With the setting in presseed.cfg the installation finishes sucessfully.

Change-UUID: 9bf4aeeb20d14d8a9b28fda33906a613
