### PR TITLE
Change ubuntu-server to server in Ubuntu 12.04 preseed

### DIFF
--- a/ubuntu-12.04/http/preseed.cfg
+++ b/ubuntu-12.04/http/preseed.cfg
@@ -34,5 +34,5 @@ d-i pkgsel/upgrade select none
 d-i time/zone string UTC
 d-i user-setup/allow-password-weak boolean true
 d-i user-setup/encrypt-home boolean false
-tasksel tasksel/first multiselect standard, ubuntu-server
+tasksel tasksel/first multiselect standard, server
 


### PR DESCRIPTION
There is no `ubuntu-server` package so effectively this wasn't installing
anything (tested on Ubuntu 12.04.5). You can check if it works by checking
if `vim` is installed (one of server packages).

I'm creating a PR for this because it looks like the most popular repo with
Packer templates. I've seen this mistake in many other places.
